### PR TITLE
Update Spec.json

### DIFF
--- a/Gantt Chart/Spec.json
+++ b/Gantt Chart/Spec.json
@@ -291,7 +291,12 @@
           "sort": {"field": "start", "order": "ascending"},
           "ops": ["rank"],
           "as": ["phaseSort"]
-        }
+        },
+        {
+          "type": "formula",
+          "as": "phaseSort",
+          "expr": "'phaseSort'+random()*0.01"
+        },
       ]
     },
     {


### PR DESCRIPTION
Hello Davide,
Thank you again for all your great Vega creations. I found a possible improvement for the gantt chart : if several phases start on the same date, the sorting of phases and tasks gets mixed up, and you basically end with phases on top, and tasks below, which is inconvenient. It is related to the Vega "Window" transform. During sorting, if two phases have the same start date, they will also get the same rank (as "peers"). To overcome this, I have created this workaround. There is probably a better solution with the Window transform itself, but I could not find it. Cheers